### PR TITLE
Add Context

### DIFF
--- a/lib/log_hog/config.ex
+++ b/lib/log_hog/config.ex
@@ -98,6 +98,10 @@ defmodule LogHog.Config do
           :in_app_modules,
           config.in_app_otp_apps |> Enum.flat_map(&Application.spec(&1, :modules)) |> MapSet.new()
         )
+        |> Map.put(:global_context, %{
+          "$lib": "LogHog",
+          "$lib_version": Application.spec(:log_hog, :vsn) |> to_string()
+        })
 
       {:ok, final_config}
     end

--- a/lib/log_hog/context.ex
+++ b/lib/log_hog/context.ex
@@ -1,0 +1,35 @@
+defmodule LogHog.Context do
+  @moduledoc """
+  Context is Logger metadata purposefully set to be exported regardless of `LogHog.Config`'s `metadata` setting.
+  """
+
+  @type t() :: map()
+
+  @logger_metadata_key :__loghog__
+
+  @doc """
+  Set context for the current process.
+  """
+  @spec set(t()) :: :ok
+  def set(new_context) do
+    context =
+      case :logger.get_process_metadata() do
+        %{@logger_metadata_key => existing} -> Map.merge(existing, new_context)
+        _ -> new_context
+      end
+
+    :logger.update_process_metadata(%{@logger_metadata_key => context})
+  end
+
+  @doc """
+  Obtain the context of the current process.
+  """
+  @spec get() :: t()
+  def get() do
+    case :logger.get_process_metadata() do
+      %{@logger_metadata_key => config} -> config
+      %{} -> %{}
+      :undefined -> %{}
+    end
+  end
+end

--- a/lib/log_hog/handler.ex
+++ b/lib/log_hog/handler.ex
@@ -45,6 +45,7 @@ defmodule LogHog.Handler do
       event: "$exception",
       properties:
         Context.get()
+        |> Map.merge(config.global_context)
         |> Map.merge(%{
           distinct_id: "unknown",
           "$exception_list": [exception]

--- a/lib/log_hog/handler.ex
+++ b/lib/log_hog/handler.ex
@@ -4,6 +4,8 @@ defmodule LogHog.Handler do
   """
   @behaviour :logger_handler
 
+  alias LogHog.Context
+
   @impl :logger_handler
   def log(log_event, %{config: config}) do
     cond do
@@ -42,13 +44,12 @@ defmodule LogHog.Handler do
     %{
       event: "$exception",
       properties:
-        Map.merge(
-          %{
-            distinct_id: "unknown",
-            "$exception_list": [exception]
-          },
-          metadata
-        )
+        Context.get()
+        |> Map.merge(%{
+          distinct_id: "unknown",
+          "$exception_list": [exception]
+        })
+        |> Map.merge(metadata)
     }
   end
 

--- a/test/log_hog/context_test.exs
+++ b/test/log_hog/context_test.exs
@@ -1,0 +1,31 @@
+defmodule LogHog.ContextTest do
+  use ExUnit.Case, async: true
+
+  alias LogHog.Context
+
+  test "sets context" do
+    assert :ok = Context.set(%{foo: "bar"})
+    assert [__loghog__: %{foo: "bar"}] = Logger.metadata()
+  end
+
+  test "context is merged" do
+    Context.set(%{foo: "bar"})
+    Context.set(%{foo: "baz", eggs: "spam"})
+
+    assert [__loghog__: %{foo: "baz", eggs: "spam"}] = Logger.metadata()
+  end
+
+  test "but not deep merged" do
+    Context.set(%{foo: %{eggs: "spam"}})
+    Context.set(%{foo: %{bar: "baz"}})
+
+    assert [__loghog__: %{foo: %{bar: "baz"}}] = Logger.metadata()
+  end
+
+  test "get/0 retrieves context" do
+    Context.set(%{foo: "bar"})
+    Logger.metadata(foo: "baz")
+
+    assert %{foo: "bar"} = Context.get()
+  end
+end


### PR DESCRIPTION
Changes:
* `LogHog.Context` module allows users to set context that is always exported in `properties`, regardless of how logger metadata is configured. This is useful, because metadata is a free-for-all wildlands: all sorts of things can be inserted it without user knowing about it. So exporting all metadata is almost never a good idea and in order to meaningfully use it users needs to either maintain a list of all metadata keys that they use and are interested at or group all their custom metadata under some non descriptive name like `extra`. The former is inconvenient and the latter results in all metadata nested under single `extra` property. `LogHog.Context.set` sets metadata that will always be exported. The con being, of course, that it's `LogHog` specific and other loggers will most likely ignore it.
* Add `global_context` `LogHog.Config` that is always attached to events. Things like `$lib` and `$lib_version` 