### PR TITLE
Mark handled errors as such

### DIFF
--- a/lib/log_hog/handler.ex
+++ b/lib/log_hog/handler.ex
@@ -29,7 +29,9 @@ defmodule LogHog.Handler do
     exception =
       Enum.reduce(
         [&type/1, &value/1, &stacktrace(&1, config.in_app_modules)],
-        %{mechanism: %{handled: true, type: "generic"}},
+        %{
+          mechanism: %{handled: not Map.has_key?(log_event.meta, :crash_reason), type: "generic"}
+        },
         fn fun, acc ->
           Map.merge(acc, fun.(log_event))
         end

--- a/test/log_hog/handler_test.exs
+++ b/test/log_hog/handler_test.exs
@@ -75,7 +75,7 @@ defmodule LogHog.HandlerTest do
                  %{
                    type: "** (exit) \"exit reason\"",
                    value: "** (exit) \"exit reason\"",
-                   mechanism: %{handled: true, type: "generic"}
+                   mechanism: %{handled: false, type: "generic"}
                  }
                ]
              }
@@ -255,7 +255,7 @@ defmodule LogHog.HandlerTest do
                  %{
                    type: "RuntimeError",
                    value: "** (RuntimeError) oops",
-                   mechanism: %{handled: true, type: "generic"},
+                   mechanism: %{handled: false, type: "generic"},
                    stacktrace: %{
                      type: "raw",
                      frames: [
@@ -298,7 +298,7 @@ defmodule LogHog.HandlerTest do
                  %{
                    type: "** (throw) \"catch!\"",
                    value: "** (throw) \"catch!\"",
-                   mechanism: %{handled: true, type: "generic"},
+                   mechanism: %{handled: false, type: "generic"},
                    stacktrace: %{
                      type: "raw",
                      frames: [
@@ -341,7 +341,7 @@ defmodule LogHog.HandlerTest do
                  %{
                    type: "** (exit) \"i quit\"",
                    value: "** (exit) \"i quit\"",
-                   mechanism: %{handled: true, type: "generic"},
+                   mechanism: %{handled: false, type: "generic"},
                    stacktrace: %{
                      type: "raw",
                      frames: [
@@ -384,7 +384,7 @@ defmodule LogHog.HandlerTest do
                  %{
                    type: "RuntimeError",
                    value: "** (RuntimeError) oops",
-                   mechanism: %{handled: true, type: "generic"},
+                   mechanism: %{handled: false, type: "generic"},
                    stacktrace: %{
                      type: "raw",
                      frames: [
@@ -446,7 +446,7 @@ defmodule LogHog.HandlerTest do
                  %{
                    type: "** (exit) \"i quit\"",
                    value: "** (exit) \"i quit\"",
-                   mechanism: %{handled: true, type: "generic"},
+                   mechanism: %{handled: false, type: "generic"},
                    stacktrace: %{
                      type: "raw",
                      frames: [
@@ -507,7 +507,7 @@ defmodule LogHog.HandlerTest do
                  %{
                    type: "** (exit) %LoggerHandlerKit.FakeStruct{hello: \"world\"}",
                    value: "** (exit) %LoggerHandlerKit.FakeStruct{hello: \"world\"}",
-                   mechanism: %{handled: true, type: "generic"}
+                   mechanism: %{handled: false, type: "generic"}
                  }
                ]
              }
@@ -527,7 +527,7 @@ defmodule LogHog.HandlerTest do
                  %{
                    type: "** (exit) bad return value: \"catch!\"",
                    value: "** (exit) bad return value: \"catch!\"",
-                   mechanism: %{handled: true, type: "generic"}
+                   mechanism: %{handled: false, type: "generic"}
                  }
                ]
              }
@@ -547,7 +547,7 @@ defmodule LogHog.HandlerTest do
                  %{
                    type: "RuntimeError",
                    value: "** (RuntimeError) oops",
-                   mechanism: %{handled: true, type: "generic"},
+                   mechanism: %{handled: false, type: "generic"},
                    stacktrace: %{
                      frames: [
                        %{
@@ -604,7 +604,7 @@ defmodule LogHog.HandlerTest do
                  %{
                    type: "RuntimeError",
                    value: "** (RuntimeError) oops",
-                   mechanism: %{handled: true, type: "generic"},
+                   mechanism: %{handled: false, type: "generic"},
                    stacktrace: %{
                      frames: [
                        %{
@@ -643,7 +643,7 @@ defmodule LogHog.HandlerTest do
                  %{
                    type: "ErlangError",
                    value: "** (ErlangError) Erlang error: {:nocatch, \"catch!\"}",
-                   mechanism: %{handled: true, type: "generic"},
+                   mechanism: %{handled: false, type: "generic"},
                    stacktrace: %{
                      frames: [
                        %{
@@ -678,7 +678,7 @@ defmodule LogHog.HandlerTest do
                  %{
                    type: "RuntimeError",
                    value: "** (RuntimeError) oops",
-                   mechanism: %{handled: true, type: "generic"},
+                   mechanism: %{handled: false, type: "generic"},
                    stacktrace: %{
                      frames: [
                        %{
@@ -741,7 +741,7 @@ defmodule LogHog.HandlerTest do
                  %{
                    type: "RuntimeError",
                    value: "** (RuntimeError) oops",
-                   mechanism: %{handled: true, type: "generic"},
+                   mechanism: %{handled: false, type: "generic"},
                    stacktrace: %{
                      frames: [
                        %{
@@ -965,7 +965,7 @@ defmodule LogHog.HandlerTest do
                        | _
                      ]
                    },
-                   mechanism: %{type: "generic", handled: true}
+                   mechanism: %{type: "generic", handled: false}
                  }
                ]
              }

--- a/test/log_hog/integrations/plug_test.exs
+++ b/test/log_hog/integrations/plug_test.exs
@@ -39,21 +39,26 @@ defmodule LogHog.Integrations.PlugTest do
 
       assert %{
                event: "$exception",
-               properties: %{
-                 distinct_id: "unknown",
-                 "$current_url": "http://localhost/exception",
-                 "$host": "localhost",
-                 "$ip": "127.0.0.1",
-                 "$pathname": "/exception",
-                 "$exception_list": [
-                   %{
-                     type: "RuntimeError",
-                     value: "** (RuntimeError) oops",
-                     mechanism: %{handled: true, type: "generic"}
-                   }
-                 ]
-               }
+               properties: properties
              } = event
+
+      assert %{
+               distinct_id: "unknown",
+               "$current_url": "http://localhost/exception",
+               "$host": "localhost",
+               "$ip": "127.0.0.1",
+               "$pathname": "/exception",
+               "$lib": "LogHog",
+               "$lib_version": "0.2.0",
+               "$exception_list": [
+                 %{
+                   type: "RuntimeError",
+                   value: "** (RuntimeError) oops",
+                   mechanism: %{handled: false, type: "generic"},
+                   stacktrace: %{type: "raw", frames: _frames}
+                 }
+               ]
+             } = properties
     end
 
     test "context is attached to throws", %{handler_ref: ref, sender_pid: sender_pid} do
@@ -65,21 +70,26 @@ defmodule LogHog.Integrations.PlugTest do
 
       assert %{
                event: "$exception",
-               properties: %{
-                 distinct_id: "unknown",
-                 "$current_url": "http://localhost/throw",
-                 "$host": "localhost",
-                 "$ip": "127.0.0.1",
-                 "$pathname": "/throw",
-                 "$exception_list": [
-                   %{
-                     type: "** (throw) \"catch!\"",
-                     value: "** (throw) \"catch!\"",
-                     mechanism: %{handled: true, type: "generic"}
-                   }
-                 ]
-               }
+               properties: properties
              } = event
+
+      assert %{
+               distinct_id: "unknown",
+               "$current_url": "http://localhost/throw",
+               "$host": "localhost",
+               "$ip": "127.0.0.1",
+               "$pathname": "/throw",
+               "$lib": "LogHog",
+               "$lib_version": "0.2.0",
+               "$exception_list": [
+                 %{
+                   type: "** (throw) \"catch!\"",
+                   value: "** (throw) \"catch!\"",
+                   mechanism: %{handled: false, type: "generic"},
+                   stacktrace: %{type: "raw", frames: _frames}
+                 }
+               ]
+             } = properties
     end
 
     test "context is attached to exit", %{handler_ref: ref, sender_pid: sender_pid} do
@@ -91,21 +101,25 @@ defmodule LogHog.Integrations.PlugTest do
 
       assert %{
                event: "$exception",
-               properties: %{
-                 distinct_id: "unknown",
-                 "$current_url": "http://localhost/exit",
-                 "$host": "localhost",
-                 "$ip": "127.0.0.1",
-                 "$pathname": "/exit",
-                 "$exception_list": [
-                   %{
-                     type: "** (exit) \"i quit\"",
-                     value: "** (exit) \"i quit\"",
-                     mechanism: %{handled: true, type: "generic"}
-                   }
-                 ]
-               }
+               properties: properties
              } = event
+
+      assert %{
+               distinct_id: "unknown",
+               "$current_url": "http://localhost/exit",
+               "$host": "localhost",
+               "$ip": "127.0.0.1",
+               "$pathname": "/exit",
+               "$lib": "LogHog",
+               "$lib_version": "0.2.0",
+               "$exception_list": [
+                 %{
+                   type: "** (exit) \"i quit\"",
+                   value: "** (exit) \"i quit\"",
+                   mechanism: %{handled: false, type: "generic"}
+                 }
+               ]
+             } = properties
     end
   end
 
@@ -118,21 +132,26 @@ defmodule LogHog.Integrations.PlugTest do
 
       assert %{
                event: "$exception",
-               properties: %{
-                 distinct_id: "unknown",
-                 "$current_url": "http://localhost/exception",
-                 "$host": "localhost",
-                 "$ip": "127.0.0.1",
-                 "$pathname": "/exception",
-                 "$exception_list": [
-                   %{
-                     type: "RuntimeError",
-                     value: "** (RuntimeError) oops",
-                     mechanism: %{handled: true, type: "generic"}
-                   }
-                 ]
-               }
+               properties: properties
              } = event
+
+      assert %{
+               distinct_id: "unknown",
+               "$current_url": "http://localhost/exception",
+               "$host": "localhost",
+               "$ip": "127.0.0.1",
+               "$pathname": "/exception",
+               "$lib": "LogHog",
+               "$lib_version": "0.2.0",
+               "$exception_list": [
+                 %{
+                   type: "RuntimeError",
+                   value: "** (RuntimeError) oops",
+                   mechanism: %{handled: false, type: "generic"},
+                   stacktrace: %{type: "raw", frames: _frames}
+                 }
+               ]
+             } = properties
     end
 
     test "context is attached to throws", %{handler_ref: ref, sender_pid: sender_pid} do
@@ -143,21 +162,26 @@ defmodule LogHog.Integrations.PlugTest do
 
       assert %{
                event: "$exception",
-               properties: %{
-                 distinct_id: "unknown",
-                 "$current_url": "http://localhost/throw",
-                 "$host": "localhost",
-                 "$ip": "127.0.0.1",
-                 "$pathname": "/throw",
-                 "$exception_list": [
-                   %{
-                     type: "** (throw) \"catch!\"",
-                     value: "** (throw) \"catch!\"",
-                     mechanism: %{handled: true, type: "generic"}
-                   }
-                 ]
-               }
+               properties: properties
              } = event
+
+      assert %{
+               distinct_id: "unknown",
+               "$current_url": "http://localhost/throw",
+               "$host": "localhost",
+               "$ip": "127.0.0.1",
+               "$pathname": "/throw",
+               "$lib": "LogHog",
+               "$lib_version": "0.2.0",
+               "$exception_list": [
+                 %{
+                   type: "** (throw) \"catch!\"",
+                   value: "** (throw) \"catch!\"",
+                   mechanism: %{handled: false, type: "generic"},
+                   stacktrace: %{type: "raw", frames: _frames}
+                 }
+               ]
+             } = properties
     end
 
     test "context is attached to exit", %{handler_ref: ref, sender_pid: sender_pid} do
@@ -168,21 +192,25 @@ defmodule LogHog.Integrations.PlugTest do
 
       assert %{
                event: "$exception",
-               properties: %{
-                 distinct_id: "unknown",
-                 "$current_url": "http://localhost/exit",
-                 "$host": "localhost",
-                 "$ip": "127.0.0.1",
-                 "$pathname": "/exit",
-                 "$exception_list": [
-                   %{
-                     type: "** (exit) \"i quit\"",
-                     value: "** (exit) \"i quit\"",
-                     mechanism: %{handled: true, type: "generic"}
-                   }
-                 ]
-               }
+               properties: properties
              } = event
+
+      assert %{
+               distinct_id: "unknown",
+               "$current_url": "http://localhost/exit",
+               "$host": "localhost",
+               "$ip": "127.0.0.1",
+               "$pathname": "/exit",
+               "$lib": "LogHog",
+               "$lib_version": "0.2.0",
+               "$exception_list": [
+                 %{
+                   type: "** (exit) \"i quit\"",
+                   value: "** (exit) \"i quit\"",
+                   mechanism: %{handled: false, type: "generic"}
+                 }
+               ]
+             } = properties
     end
   end
 end


### PR DESCRIPTION
The line between handled and unhandled error is blurred. The best rule of thumb we have is the presence of `crash_reason` key in metadata. 