### PR TITLE
Add LogHog.capture

### DIFF
--- a/lib/log_hog.ex
+++ b/lib/log_hog.ex
@@ -1,2 +1,55 @@
 defmodule LogHog do
+  @doc """
+  Returns configuration map for a named `LogHog` supervisor
+
+  ## Example
+
+  Retrieve the default `LogHog` instance config:
+
+      %{supervisor_name: LogHog} = LogHog.config()
+      
+  Retrieve named instance config:
+
+      %{supervisor_name: MyLogHog} = LogHog.config(MyLogHog)
+  """
+  def config(name \\ __MODULE__), do: LogHog.Registry.config(name)
+
+  @doc false
+  def capture(event, distinct_id, %{} = properties),
+    do: capture(__MODULE__, event, distinct_id, properties)
+
+  @doc """
+  Captures a single event
+
+  Capture is a relatively lightweight operation. The event is prepared
+  synchronously and then sent to LogHog workers to be batched together with
+  other events and sent over the wire.
+
+  ## Examples
+
+  Capture simple event:
+
+      LogHog.capture("event captured", "user123")
+      
+  Capture event with properies:
+
+      LogHog.capture("event captures", "user123", %{backend: "Phoenix"})
+      
+  Capture through a named LogHog instance:
+
+      LogHog.capture(MyLogHog, "event_captures", "user123")
+  """
+  def capture(name \\ __MODULE__, event, distinct_id, properties \\ %{}) do
+    config = LogHog.Registry.config(name)
+    properties = Map.merge(properties, config.global_properties)
+
+    event = %{
+      event: event,
+      distinct_id: distinct_id,
+      timestamp: DateTime.utc_now() |> DateTime.to_iso8601(),
+      properties: properties
+    }
+
+    LogHog.Sender.send(event, name)
+  end
 end

--- a/lib/log_hog/config.ex
+++ b/lib/log_hog/config.ex
@@ -98,7 +98,7 @@ defmodule LogHog.Config do
           :in_app_modules,
           config.in_app_otp_apps |> Enum.flat_map(&Application.spec(&1, :modules)) |> MapSet.new()
         )
-        |> Map.put(:global_context, %{
+        |> Map.put(:global_properties, %{
           "$lib": "LogHog",
           "$lib_version": Application.spec(:log_hog, :vsn) |> to_string()
         })

--- a/lib/log_hog/registry.ex
+++ b/lib/log_hog/registry.ex
@@ -1,5 +1,14 @@
 defmodule LogHog.Registry do
   @moduledoc false
+  def config(supervisor_name) do
+    {:ok, config} =
+      supervisor_name
+      |> registry_name()
+      |> Registry.meta(:config)
+
+    config
+  end
+
   def registry_name(supervisor_name), do: Module.concat(supervisor_name, Registry)
 
   def via(supervisor_name, server_name),

--- a/lib/log_hog/supervisor.ex
+++ b/lib/log_hog/supervisor.ex
@@ -26,7 +26,10 @@ defmodule LogHog.Supervisor do
   def init({config, callers}) do
     children =
       [
-        {Registry, keys: :unique, name: LogHog.Registry.registry_name(config.supervisor_name)},
+        {Registry,
+         keys: :unique,
+         name: LogHog.Registry.registry_name(config.supervisor_name),
+         meta: [config: config]},
         {LogHog.Sender,
          [
            api_client: config.api_client,

--- a/test/log_hog/handler_test.exs
+++ b/test/log_hog/handler_test.exs
@@ -7,6 +7,7 @@ defmodule LogHog.HandlerTest do
   @moduletag capture_log: true
 
   setup {LoggerHandlerKit.Arrange, :ensure_per_handler_translation}
+  setup :setup_supervisor
   setup :setup_logger_handler
 
   test "takes distinct_id from metadata", %{handler_ref: ref, sender_pid: sender_pid} do
@@ -17,8 +18,8 @@ defmodule LogHog.HandlerTest do
 
     assert %{
              event: "$exception",
+             distinct_id: "foo",
              properties: %{
-               distinct_id: "foo",
                "$exception_list": [
                  %{
                    type: "Hello World",
@@ -70,7 +71,6 @@ defmodule LogHog.HandlerTest do
     assert %{
              event: "$exception",
              properties: %{
-               distinct_id: "unknown",
                "$exception_list": [
                  %{
                    type: "** (exit) \"exit reason\"",
@@ -427,8 +427,7 @@ defmodule LogHog.HandlerTest do
                      ]
                    }
                  }
-               ],
-               distinct_id: "unknown"
+               ]
              }
            } = event
   end
@@ -581,8 +580,7 @@ defmodule LogHog.HandlerTest do
                      type: "raw"
                    }
                  }
-               ],
-               distinct_id: "unknown"
+               ]
              }
            } = event
   end
@@ -620,8 +618,7 @@ defmodule LogHog.HandlerTest do
                      type: "raw"
                    }
                  }
-               ],
-               distinct_id: "unknown"
+               ]
              }
            } = event
   end
@@ -923,7 +920,6 @@ defmodule LogHog.HandlerTest do
     assert %{
              event: "$exception",
              properties: %{
-               distinct_id: "unknown",
                foo: "bar",
                "$exception_list": [
                  %{

--- a/test/log_hog/integrations/plug_test.exs
+++ b/test/log_hog/integrations/plug_test.exs
@@ -4,6 +4,7 @@ defmodule LogHog.Integrations.PlugTest do
   @moduletag capture_log: true, config: [capture_level: :error]
 
   setup {LoggerHandlerKit.Arrange, :ensure_per_handler_translation}
+  setup :setup_supervisor
   setup :setup_logger_handler
 
   defmodule MyRouter do
@@ -43,7 +44,6 @@ defmodule LogHog.Integrations.PlugTest do
              } = event
 
       assert %{
-               distinct_id: "unknown",
                "$current_url": "http://localhost/exception",
                "$host": "localhost",
                "$ip": "127.0.0.1",
@@ -74,7 +74,6 @@ defmodule LogHog.Integrations.PlugTest do
              } = event
 
       assert %{
-               distinct_id: "unknown",
                "$current_url": "http://localhost/throw",
                "$host": "localhost",
                "$ip": "127.0.0.1",
@@ -105,7 +104,6 @@ defmodule LogHog.Integrations.PlugTest do
              } = event
 
       assert %{
-               distinct_id: "unknown",
                "$current_url": "http://localhost/exit",
                "$host": "localhost",
                "$ip": "127.0.0.1",
@@ -136,7 +134,6 @@ defmodule LogHog.Integrations.PlugTest do
              } = event
 
       assert %{
-               distinct_id: "unknown",
                "$current_url": "http://localhost/exception",
                "$host": "localhost",
                "$ip": "127.0.0.1",
@@ -166,7 +163,6 @@ defmodule LogHog.Integrations.PlugTest do
              } = event
 
       assert %{
-               distinct_id: "unknown",
                "$current_url": "http://localhost/throw",
                "$host": "localhost",
                "$ip": "127.0.0.1",
@@ -196,7 +192,6 @@ defmodule LogHog.Integrations.PlugTest do
              } = event
 
       assert %{
-               distinct_id: "unknown",
                "$current_url": "http://localhost/exit",
                "$host": "localhost",
                "$ip": "127.0.0.1",

--- a/test/log_hog_test.exs
+++ b/test/log_hog_test.exs
@@ -1,0 +1,74 @@
+defmodule LogHogTest do
+  use LogHog.Case, async: true
+
+  @moduletag config: [supervisor_name: LogHog]
+
+  setup :setup_supervisor
+
+  describe "config/0" do
+    test "fetches from LogHog by default" do
+      assert %{supervisor_name: LogHog} = LogHog.config()
+    end
+
+    @tag config: [supervisor_name: CustomLogHog]
+    test "uses custom supervisor name" do
+      assert %{supervisor_name: CustomLogHog} = LogHog.config(CustomLogHog)
+    end
+  end
+
+  describe "capture/4" do
+    test "simple call", %{sender_pid: sender_pid} do
+      LogHog.capture("case tested", "distinct_id")
+
+      assert %{events: [event]} = :sys.get_state(sender_pid)
+
+      assert %{
+               event: "case tested",
+               distinct_id: "distinct_id",
+               properties: %{},
+               timestamp: _
+             } = event
+    end
+
+    test "with properties", %{sender_pid: sender_pid} do
+      LogHog.capture("case tested", "distinct_id", %{foo: "bar"})
+
+      assert %{events: [event]} = :sys.get_state(sender_pid)
+
+      assert %{
+               event: "case tested",
+               distinct_id: "distinct_id",
+               properties: %{foo: "bar"},
+               timestamp: _
+             } = event
+    end
+
+    @tag config: [supervisor_name: CustomLogHog]
+    test "simple call for custom supervisor", %{sender_pid: sender_pid} do
+      LogHog.capture(CustomLogHog, "case tested", "distinct_id")
+
+      assert %{events: [event]} = :sys.get_state(sender_pid)
+
+      assert %{
+               event: "case tested",
+               distinct_id: "distinct_id",
+               properties: %{},
+               timestamp: _
+             } = event
+    end
+
+    @tag config: [supervisor_name: CustomLogHog]
+    test "with properties for custom supervisor", %{sender_pid: sender_pid} do
+      LogHog.capture(CustomLogHog, "case tested", "distinct_id", %{foo: "bar"})
+
+      assert %{events: [event]} = :sys.get_state(sender_pid)
+
+      assert %{
+               event: "case tested",
+               distinct_id: "distinct_id",
+               properties: %{foo: "bar"},
+               timestamp: _
+             } = event
+    end
+  end
+end


### PR DESCRIPTION
Adding generic capture. The complicated part here is the way we think about configuration. Library guidelines discourage library authors from reading global configuration and starting their own supervision trees. Instead, they should instruct users to start library supervisor under their app's supervision tree and pass configuration explicitly. That would be a very good thing to do if not for error tracking. Logger handler ideally should be started as soon as possible and by the time it's started the supervision tree should already be available. 

That's why LogHog is going to combine both approaches. The default way of using LogHog will be just configuring it globally with `config :log_hog, ...`. In that case LogHog app will start everything and attach the logger handler. `LogHog.capture(event, distinct_id)` usage will naturally work with that setup.

Alternatively, user is able to start any number of named LogHog instances and attach any number of logger handlers themselves. For those cases, the interface is `LogHog.capture(MyLogHog, event, distinct_id)`. This is pretty much what Oban does, minus facade mechanism.