### PR TITLE
Support feature flags

### DIFF
--- a/lib/log_hog.ex
+++ b/lib/log_hog.ex
@@ -52,4 +52,20 @@ defmodule LogHog do
 
     LogHog.Sender.send(event, name)
   end
+
+  def get_feature_flag(name \\ __MODULE__, distinct_id_or_body) do
+    body =
+      case distinct_id_or_body do
+        %{} = body -> body
+        distinct_id -> %{distinct_id: distinct_id}
+      end
+
+    config = config(name)
+
+    case LogHog.API.flags(config.api_client, body) do
+      {:ok, %{status: 200, body: body}} -> {:ok, body}
+      {:ok, resp} -> {:error, resp}
+      {:error, error} -> {:error, error}
+    end
+  end
 end

--- a/lib/log_hog/api.ex
+++ b/lib/log_hog/api.ex
@@ -3,4 +3,8 @@ defmodule LogHog.API do
   def post_batch(%__MODULE__.Client{} = client, batch) do
     client.module.request(client.client, :post, "/batch", json: %{batch: batch})
   end
+
+  def flags(%__MODULE__.Client{} = client, event) do
+    client.module.request(client.client, :post, "/flags", json: event, params: %{v: 2})
+  end
 end

--- a/test/log_hog_test.exs
+++ b/test/log_hog_test.exs
@@ -3,7 +3,12 @@ defmodule LogHogTest do
 
   @moduletag config: [supervisor_name: LogHog]
 
+  import Mox
+
+  alias LogHog.API
+
   setup :setup_supervisor
+  setup :verify_on_exit!
 
   describe "config/0" do
     test "fetches from LogHog by default" do
@@ -69,6 +74,65 @@ defmodule LogHogTest do
                properties: %{foo: "bar"},
                timestamp: _
              } = event
+    end
+  end
+
+  describe "get_feature_flag/2" do
+    test "returns body on success" do
+      expect(API.Mock, :request, fn _client, method, url, opts ->
+        assert method == :post
+        assert url == "/flags"
+        assert opts[:params] == %{v: 2}
+
+        assert opts[:json] == %{
+                 distinct_id: "foo"
+               }
+
+        {:ok, %{status: 200, body: "body"}}
+      end)
+
+      assert {:ok, "body"} = LogHog.get_feature_flag("foo")
+    end
+
+    test "sophisticated body" do
+      expect(API.Mock, :request, fn client, method, url, opts ->
+        assert opts[:json] == %{
+                 distinct_id: "foo",
+                 groups: %{group_type: "group_id"}
+               }
+
+        API.Stub.request(client, method, url, opts)
+      end)
+
+      assert {:ok, %{}} =
+               LogHog.get_feature_flag(%{distinct_id: "foo", groups: %{group_type: "group_id"}})
+    end
+
+    test "errors passed as is" do
+      expect(API.Mock, :request, fn _client, _method, _url, _opts ->
+        {:error, :transport_error}
+      end)
+
+      assert {:error, :transport_error} = LogHog.get_feature_flag("foo")
+    end
+
+    test "non-200 is wrapped in error" do
+      expect(API.Mock, :request, fn _client, _method, _url, _opts ->
+        {:ok, %{status: 503}}
+      end)
+
+      assert {:error, %{status: 503}} = LogHog.get_feature_flag("foo")
+    end
+
+    @tag config: [supervisor_name: MyLogHog]
+    test "custom LogHog instance" do
+      expect(API.Mock, :request, fn client, method, url, opts ->
+        assert opts[:json] == %{distinct_id: "foo"}
+
+        API.Stub.request(client, method, url, opts)
+      end)
+
+      assert {:ok, %{}} = LogHog.get_feature_flag(MyLogHog, "foo")
     end
   end
 end

--- a/test/support/api/stub.ex
+++ b/test/support/api/stub.ex
@@ -7,7 +7,36 @@ defmodule LogHog.API.Stub do
   end
 
   @impl LogHog.API.Client
-  def request(_client, :post, "/i/v0/e", _opts) do
+  def request(_client, :post, "/batch", _opts) do
     {:ok, %{status: 200, body: %{"status" => "Ok"}}}
+  end
+
+  def request(_client, :post, "/flags", _opts) do
+    {:ok,
+     %{
+       status: 200,
+       body: %{
+         "errorsWhileComputingFlags" => false,
+         "flags" => %{
+           "example-feature-flag-1" => %{
+             "enabled" => true,
+             "key" => "example-feature-flag-1",
+             "metadata" => %{
+               "description" => nil,
+               "id" => 154_429,
+               "payload" => nil,
+               "version" => 4
+             },
+             "reason" => %{
+               "code" => "condition_match",
+               "condition_index" => 0,
+               "description" => "Matched condition set 1"
+             },
+             "variant" => nil
+           }
+         },
+         "requestId" => "0d23f243-399a-4904-b1a8-ec2037834b72"
+       }
+     }}
   end
 end


### PR DESCRIPTION
There's quite a bit of variety in how feature flags can be used and thus a lot of decision to be made, which I'm not ready to make. For now, I think it's best to have a simple wrapper function around API request and let users build their own helper on top. 