### PR TITLE
LogHog.set_context and friends

### DIFF
--- a/lib/log_hog.ex
+++ b/lib/log_hog.ex
@@ -68,4 +68,81 @@ defmodule LogHog do
       {:error, error} -> {:error, error}
     end
   end
+
+  @doc """
+  Set context for the current process.
+
+  ## Examples
+
+  Set and retrieve context for current process:
+
+      > LogHog.set_context(%{foo: "bar"})
+      > LogHog.get_context()
+      %{foo: "bar"}
+
+  Set and retrieve context for a named LogHog instance:
+
+      > LogHog.set_context(MyLogHog, %{foo: "bar"})
+      > LogHog.get_context(MyLogHog)
+      %{foo: "bar"}
+  """
+  def set_context(name \\ __MODULE__, context), do: LogHog.Context.set(name, :all, context)
+
+  @doc """
+  Set context for the current process scoped for a specific event.
+
+  ## Examples
+
+  Set and retrieve context scoped for event:
+
+      > LogHog.set_event_context("$exception", %{foo: "bar"})
+      > LogHog.get_event_context("$exception")
+      %{foo: "bar"}
+     
+  Set and retrieve context for a specific event through a named LogHog instance:
+
+      > LogHog.set_event_context(MyLogHog, "$exception", %{foo: "bar"})
+      > LogHog.get_event_context(MyLogHog, "$exception")
+      %{foo: "bar"}
+  """
+  def set_event_context(name \\ __MODULE__, event, context),
+    do: LogHog.Context.set(name, event, context)
+
+  @doc """
+  Retrieves context for the current process.
+
+  ## Examples
+
+  Set and retrieve context for current process:
+
+      > LogHog.set_context(%{foo: "bar"})
+      > LogHog.get_context()
+      %{foo: "bar"}
+      
+  Set and retrieve context for a named LogHog instance:
+
+      > LogHog.set_context(MyLogHog, %{foo: "bar"})
+      > LogHog.get_context(MyLogHog)
+      %{foo: "bar"}
+  """
+  def get_context(name \\ __MODULE__), do: LogHog.Context.get(name, :all)
+
+  @doc """
+  Retrieves context for the current process scoped for a specific event.
+
+  ## Examples
+
+  Set and retrieve context scoped for event:
+
+      > LogHog.set_event_context("$exception", %{foo: "bar"})
+      > LogHog.get_event_context("$exception")
+      %{foo: "bar"}
+     
+  Set and retrieve context for a specific event through a named LogHog instance:
+
+      > LogHog.set_event_context(MyLogHog, "$exception", %{foo: "bar"})
+      > LogHog.get_event_context(MyLogHog, "$exception")
+      %{foo: "bar"}
+  """
+  def get_event_context(name \\ __MODULE__, event), do: LogHog.Context.get(name, event)
 end

--- a/lib/log_hog/context.ex
+++ b/lib/log_hog/context.ex
@@ -1,35 +1,45 @@
 defmodule LogHog.Context do
-  @moduledoc """
-  Context is Logger metadata purposefully set to be exported regardless of `LogHog.Config`'s `metadata` setting.
-  """
-
-  @type t() :: map()
+  @moduledoc false
 
   @logger_metadata_key :__loghog__
 
-  @doc """
-  Set context for the current process.
-  """
-  @spec set(t()) :: :ok
-  def set(new_context) do
-    context =
-      case :logger.get_process_metadata() do
-        %{@logger_metadata_key => existing} -> Map.merge(existing, new_context)
-        _ -> new_context
+  def set(name_scope, event_scope, context) do
+    metadata =
+      with :undefined <- :logger.get_process_metadata(), do: %{}
+
+    current_context = Map.get(metadata, @logger_metadata_key, %{})
+
+    new_value =
+      case get_in(current_context, [name_scope, event_scope]) do
+        %{} = existing -> Map.merge(existing, context)
+        nil -> context
       end
 
-    :logger.update_process_metadata(%{@logger_metadata_key => context})
+    updated_context =
+      put_in(
+        current_context,
+        [Access.key(name_scope, %{}), Access.key(event_scope, %{})],
+        new_value
+      )
+
+    :logger.update_process_metadata(%{@logger_metadata_key => updated_context})
   end
 
-  @doc """
-  Obtain the context of the current process.
-  """
-  @spec get() :: t()
-  def get() do
+  def get(name_scope, event_scope) do
     case :logger.get_process_metadata() do
-      %{@logger_metadata_key => config} -> config
-      %{} -> %{}
-      :undefined -> %{}
+      %{@logger_metadata_key => context} ->
+        get_in(context, [key_and_all(name_scope), key_and_all(event_scope)]) |> Map.new()
+
+      _ ->
+        %{}
+    end
+  end
+
+  defp key_and_all(key) do
+    fn :get, data, next ->
+      scoped = Map.get(data, key, %{})
+      all = Map.get(data, :all, %{})
+      Enum.flat_map([all, scoped], next)
     end
   end
 end

--- a/lib/log_hog/handler.ex
+++ b/lib/log_hog/handler.ex
@@ -53,7 +53,7 @@ defmodule LogHog.Handler do
       |> Map.drop(["$exception_list"])
       |> LoggerJSON.Formatter.RedactorEncoder.encode([])
 
-    Context.get()
+    Context.get(config.supervisor_name, "$exception")
     |> enrich_context(log_event)
     |> Map.put(:"$exception_list", [exception])
     |> Map.merge(metadata)

--- a/lib/log_hog/integrations/plug.ex
+++ b/lib/log_hog/integrations/plug.ex
@@ -25,9 +25,8 @@ defmodule LogHog.Integrations.Plug do
 
   @doc false
   def call(conn, _opts) do
-    conn
-    |> conn_to_context()
-    |> LogHog.Context.set()
+    context = conn_to_context(conn)
+    LogHog.Context.set(:all, "$exception", context)
 
     conn
   end

--- a/test/log_hog/context_test.exs
+++ b/test/log_hog/context_test.exs
@@ -3,29 +3,59 @@ defmodule LogHog.ContextTest do
 
   alias LogHog.Context
 
-  test "sets context" do
-    assert :ok = Context.set(%{foo: "bar"})
-    assert [__loghog__: %{foo: "bar"}] = Logger.metadata()
+  test "sets context for specific scope" do
+    assert :ok = Context.set(LogHog, "$exception", %{foo: "bar"})
+    assert [__loghog__: %{LogHog => %{"$exception" => %{foo: "bar"}}}] = Logger.metadata()
   end
 
   test "context is merged" do
-    Context.set(%{foo: "bar"})
-    Context.set(%{foo: "baz", eggs: "spam"})
+    Context.set(LogHog, "$exception", %{foo: "bar"})
+    Context.set(LogHog, "$exception", %{foo: "baz", eggs: "spam"})
 
-    assert [__loghog__: %{foo: "baz", eggs: "spam"}] = Logger.metadata()
+    assert [__loghog__: %{LogHog => %{"$exception" => %{eggs: "spam", foo: "baz"}}}] =
+             Logger.metadata()
   end
 
   test "but not deep merged" do
-    Context.set(%{foo: %{eggs: "spam"}})
-    Context.set(%{foo: %{bar: "baz"}})
+    Context.set(LogHog, "$exception", %{foo: %{eggs: "spam"}})
+    Context.set(LogHog, "$exception", %{foo: %{bar: "baz"}})
 
-    assert [__loghog__: %{foo: %{bar: "baz"}}] = Logger.metadata()
+    assert [__loghog__: %{LogHog => %{"$exception" => %{foo: %{bar: "baz"}}}}] = Logger.metadata()
   end
 
-  test "get/0 retrieves context" do
-    Context.set(%{foo: "bar"})
+  test "multiple scopes" do
+    Context.set(LogHog, :all, %{foo: "bar"})
+    Context.set(MyLogHog, "$exception", %{foo: "baz"})
+    Context.set(:all, :all, %{hello: "world"})
+
+    assert [
+             __loghog__: %{
+               LogHog => %{all: %{foo: "bar"}},
+               MyLogHog => %{"$exception" => %{foo: "baz"}},
+               all: %{all: %{hello: "world"}}
+             }
+           ] = Logger.metadata()
+  end
+
+  test "get/0 retrieves context with scope + all" do
+    Context.set(LogHog, :all, %{foo: "bar"})
+    Context.set(MyLogHog, "$exception", %{foo: "baz"})
+    Context.set(:all, :all, %{hello: "world"})
     Logger.metadata(foo: "baz")
 
-    assert %{foo: "bar"} = Context.get()
+    assert %{foo: "bar", hello: "world"} = Context.get(LogHog, "$exception")
+    assert %{foo: "baz", hello: "world"} = Context.get(MyLogHog, "$exception")
+    assert %{hello: "world"} = Context.get(MyLogHog, "$exception_list")
+    assert %{hello: "world"} = Context.get(FooBar, "$exception")
+  end
+
+  test "in case of overlapping keys prefer more specific scope" do
+    Context.set(LogHog, :all, %{foo: 1})
+    Context.set(LogHog, "$exception", %{foo: 2})
+    Context.set(:all, :all, %{foo: 3})
+    Context.set(:all, "$exception", %{foo: 4})
+
+    assert %{foo: 2} = Context.get(LogHog, "$exception")
+    assert %{foo: 4} = Context.get(:all, "$exception")
   end
 end

--- a/test/log_hog/handler_test.exs
+++ b/test/log_hog/handler_test.exs
@@ -2,7 +2,6 @@ defmodule LogHog.HandlerTest do
   use LogHog.Case, async: true
 
   require Logger
-  alias LogHog.Context
 
   @moduletag capture_log: true
 
@@ -910,8 +909,12 @@ defmodule LogHog.HandlerTest do
   end
 
   @tag config: [metadata: [:extra]]
-  test "purposefully set context is always exported", %{handler_ref: ref, sender_pid: sender_pid} do
-    Context.set(%{foo: "bar"})
+  test "purposefully set context is always exported", %{
+    config: config,
+    handler_ref: ref,
+    sender_pid: sender_pid
+  } do
+    LogHog.set_context(config.supervisor_name, %{foo: "bar"})
     Logger.error("Error with metadata", hello: "world")
     LoggerHandlerKit.Assert.assert_logged(ref)
 

--- a/test/log_hog/integrations/plug_test.exs
+++ b/test/log_hog/integrations/plug_test.exs
@@ -22,7 +22,7 @@ defmodule LogHog.Integrations.PlugTest do
     conn = Plug.Test.conn(:get, "https://posthog.com/foo?bar=10")
     assert LogHog.Integrations.Plug.call(conn, nil)
 
-    assert LogHog.Context.get() == %{
+    assert LogHog.Context.get(:all, "$exception") == %{
              "$current_url": "https://posthog.com/foo?bar=10",
              "$host": "posthog.com",
              "$ip": "127.0.0.1",

--- a/test/log_hog_test.exs
+++ b/test/log_hog_test.exs
@@ -135,4 +135,40 @@ defmodule LogHogTest do
       assert {:ok, %{}} = LogHog.get_feature_flag(MyLogHog, "foo")
     end
   end
+
+  describe "set_context/2 + get_context/2" do
+    test "default scope" do
+      LogHog.set_context(%{foo: "bar"})
+      assert LogHog.get_context() == %{foo: "bar"}
+      assert LogHog.get_context(LogHog) == %{foo: "bar"}
+      assert LogHog.get_event_context("$exception") == %{foo: "bar"}
+      assert LogHog.get_event_context(LogHog, "$exception") == %{foo: "bar"}
+    end
+
+    test "named scope, all events" do
+      LogHog.set_context(MyLogHog, %{foo: "bar"})
+      assert LogHog.get_context() == %{}
+      assert LogHog.get_event_context("$exception") == %{}
+      assert LogHog.get_context(MyLogHog) == %{foo: "bar"}
+      assert LogHog.get_event_context(MyLogHog, "$exception") == %{foo: "bar"}
+    end
+  end
+
+  describe "set_event_context/2 + get_event_context/2" do
+    test "default scope" do
+      LogHog.set_event_context("$exception", %{foo: "bar"})
+      assert LogHog.get_context() == %{}
+      assert LogHog.get_event_context("$exception") == %{foo: "bar"}
+      assert LogHog.get_context(LogHog) == %{}
+      assert LogHog.get_event_context(LogHog, "$exception") == %{foo: "bar"}
+    end
+
+    test "named scope" do
+      LogHog.set_event_context(MyLogHog, "$exception", %{foo: "bar"})
+      assert LogHog.get_context() == %{}
+      assert LogHog.get_event_context("$exception") == %{}
+      assert LogHog.get_context(MyLogHog) == %{}
+      assert LogHog.get_event_context(MyLogHog, "$exception") == %{foo: "bar"}
+    end
+  end
 end


### PR DESCRIPTION
The concept of context used by error tracking and specifically `LogHog.Integrations.Plug` can be expanded so that users could use it anywhere in the app. Most notable example, of course, is setting`distinct_id`. Another one is [including `"$feature/feature-flag-key"` property](https://posthog.com/docs/feature-flags/adding-feature-flag-code#step-2-include-feature-flag-information-when-capturing-events) in all events captured after a feature flag was checked.