### PR TITLE
Rethink LogHog.capture and introduce LogHog.bare_capture

### DIFF
--- a/lib/log_hog.ex
+++ b/lib/log_hog.ex
@@ -15,11 +15,11 @@ defmodule LogHog do
   def config(name \\ __MODULE__), do: LogHog.Registry.config(name)
 
   @doc false
-  def capture(event, distinct_id, %{} = properties),
-    do: capture(__MODULE__, event, distinct_id, properties)
+  def bare_capture(event, distinct_id, %{} = properties),
+    do: bare_capture(__MODULE__, event, distinct_id, properties)
 
   @doc """
-  Captures a single event
+  Captures a single event without retrieving properties from context.
 
   Capture is a relatively lightweight operation. The event is prepared
   synchronously and then sent to LogHog workers to be batched together with
@@ -29,17 +29,17 @@ defmodule LogHog do
 
   Capture simple event:
 
-      LogHog.capture("event captured", "user123")
+      LogHog.bare_capture("event captured", "user123")
       
   Capture event with properies:
 
-      LogHog.capture("event captures", "user123", %{backend: "Phoenix"})
+      LogHog.bare_capture("event captures", "user123", %{backend: "Phoenix"})
       
   Capture through a named LogHog instance:
 
-      LogHog.capture(MyLogHog, "event_captures", "user123")
+      LogHog.bare_capture(MyLogHog, "event_captures", "user123")
   """
-  def capture(name \\ __MODULE__, event, distinct_id, properties \\ %{}) do
+  def bare_capture(name \\ __MODULE__, event, distinct_id, properties \\ %{}) do
     config = LogHog.Registry.config(name)
     properties = Map.merge(properties, config.global_properties)
 
@@ -51,6 +51,40 @@ defmodule LogHog do
     }
 
     LogHog.Sender.send(event, name)
+  end
+
+  @doc false
+  def capture(event, %{} = properties),
+    do: capture(__MODULE__, event, properties)
+
+  @doc """
+  Captures a single event.
+
+  Any context previously set will be included in the event properties. Note that
+  `distinct_id` is still required.
+
+  ## Examples
+
+  Set context and capture event:
+
+      LogHog.set_context(%{distinct_id: "user123", "$feature/my-feature-flag": true})
+      LogHog.capture("job started", %{job_name: "JobName"})
+      
+  Set context and capture event through a named LogHog instance:
+
+      LogHog.set_context(MyLogHog, %{distinct_id: "user123", "$feature/my-feature-flag": true})
+      LogHog.capture(MyLogHog, "job started", %{job_name: "JobName"})
+  """
+  def capture(name \\ __MODULE__, event, properties \\ %{}) do
+    context =
+      name
+      |> get_event_context(event)
+      |> Map.merge(properties)
+
+    case Map.pop(context, :distinct_id) do
+      {nil, _} -> {:error, :missing_distinct_id}
+      {distinct_id, properties} -> bare_capture(name, event, distinct_id, properties)
+    end
   end
 
   def get_feature_flag(name \\ __MODULE__, distinct_id_or_body) do

--- a/lib/log_hog/handler.ex
+++ b/lib/log_hog/handler.ex
@@ -24,7 +24,7 @@ defmodule LogHog.Handler do
       end
 
     with %{} = properties <- maybe_properties do
-      LogHog.capture(
+      LogHog.bare_capture(
         config.supervisor_name,
         "$exception",
         Map.get(properties, :distinct_id, "unknown"),

--- a/test/log_hog/integrations/plug_test.exs
+++ b/test/log_hog/integrations/plug_test.exs
@@ -1,5 +1,7 @@
 defmodule LogHog.Integrations.PlugTest do
-  use LogHog.Case, async: true
+  # This unfortunately will be flaky in async mode until
+  # https://github.com/erlang/otp/issues/9997 is fixed
+  use LogHog.Case, async: false
 
   @moduletag capture_log: true, config: [capture_level: :error]
 

--- a/test/log_hog_test.exs
+++ b/test/log_hog_test.exs
@@ -21,9 +21,9 @@ defmodule LogHogTest do
     end
   end
 
-  describe "capture/4" do
+  describe "bare_capture/4" do
     test "simple call", %{sender_pid: sender_pid} do
-      LogHog.capture("case tested", "distinct_id")
+      LogHog.bare_capture("case tested", "distinct_id")
 
       assert %{events: [event]} = :sys.get_state(sender_pid)
 
@@ -36,7 +36,7 @@ defmodule LogHogTest do
     end
 
     test "with properties", %{sender_pid: sender_pid} do
-      LogHog.capture("case tested", "distinct_id", %{foo: "bar"})
+      LogHog.bare_capture("case tested", "distinct_id", %{foo: "bar"})
 
       assert %{events: [event]} = :sys.get_state(sender_pid)
 
@@ -50,7 +50,7 @@ defmodule LogHogTest do
 
     @tag config: [supervisor_name: CustomLogHog]
     test "simple call for custom supervisor", %{sender_pid: sender_pid} do
-      LogHog.capture(CustomLogHog, "case tested", "distinct_id")
+      LogHog.bare_capture(CustomLogHog, "case tested", "distinct_id")
 
       assert %{events: [event]} = :sys.get_state(sender_pid)
 
@@ -64,7 +64,7 @@ defmodule LogHogTest do
 
     @tag config: [supervisor_name: CustomLogHog]
     test "with properties for custom supervisor", %{sender_pid: sender_pid} do
-      LogHog.capture(CustomLogHog, "case tested", "distinct_id", %{foo: "bar"})
+      LogHog.bare_capture(CustomLogHog, "case tested", "distinct_id", %{foo: "bar"})
 
       assert %{events: [event]} = :sys.get_state(sender_pid)
 
@@ -72,6 +72,96 @@ defmodule LogHogTest do
                event: "case tested",
                distinct_id: "distinct_id",
                properties: %{foo: "bar"},
+               timestamp: _
+             } = event
+    end
+
+    test "ignores set context but uses global one from the config", %{sender_pid: sender_pid} do
+      LogHog.set_context(%{hello: "world"})
+      LogHog.bare_capture("case tested", "distinct_id", %{foo: "bar"})
+
+      assert %{events: [%{properties: properties}]} = :sys.get_state(sender_pid)
+
+      assert %{foo: "bar", "$lib": "LogHog", "$lib_version": _} = properties
+      refute properties[:hello]
+    end
+  end
+
+  describe "capture/4" do
+    test "simple call", %{sender_pid: sender_pid} do
+      LogHog.capture("case tested", %{distinct_id: "distinct_id"})
+
+      assert %{events: [event]} = :sys.get_state(sender_pid)
+
+      assert %{
+               event: "case tested",
+               distinct_id: "distinct_id",
+               properties: %{},
+               timestamp: _
+             } = event
+    end
+
+    test "distinct_id is required" do
+      assert {:error, :missing_distinct_id} = LogHog.capture("case tested")
+    end
+
+    test "with properties", %{sender_pid: sender_pid} do
+      LogHog.capture("case tested", %{distinct_id: "distinct_id", foo: "bar"})
+
+      assert %{events: [event]} = :sys.get_state(sender_pid)
+
+      assert %{
+               event: "case tested",
+               distinct_id: "distinct_id",
+               properties: %{foo: "bar"},
+               timestamp: _
+             } = event
+    end
+
+    @tag config: [supervisor_name: CustomLogHog]
+    test "simple call for custom supervisor", %{sender_pid: sender_pid} do
+      LogHog.capture(CustomLogHog, "case tested", %{distinct_id: "distinct_id"})
+
+      assert %{events: [event]} = :sys.get_state(sender_pid)
+
+      assert %{
+               event: "case tested",
+               distinct_id: "distinct_id",
+               properties: %{},
+               timestamp: _
+             } = event
+    end
+
+    @tag config: [supervisor_name: CustomLogHog]
+    test "with properties for custom supervisor", %{sender_pid: sender_pid} do
+      LogHog.capture(CustomLogHog, "case tested", %{distinct_id: "distinct_id", foo: "bar"})
+
+      assert %{events: [event]} = :sys.get_state(sender_pid)
+
+      assert %{
+               event: "case tested",
+               distinct_id: "distinct_id",
+               properties: %{foo: "bar"},
+               timestamp: _
+             } = event
+    end
+
+    test "includes relevant event context", %{sender_pid: sender_pid} do
+      LogHog.set_context(%{hello: "world", distinct_id: "distinct_id"})
+      LogHog.set_event_context("case tested", %{foo: "bar"})
+      LogHog.set_context(MyLogHog, %{spam: "eggs"})
+      LogHog.capture("case tested", %{final: "override"})
+
+      assert %{events: [event]} = :sys.get_state(sender_pid)
+
+      assert %{
+               event: "case tested",
+               distinct_id: "distinct_id",
+               properties: %{
+                 hello: "world",
+                 foo: "bar",
+                 final: "override"
+               },
                timestamp: _
              } = event
     end


### PR DESCRIPTION
Main `LogHog.capture/4` now reads from the Context as thus not require an explicitly passed `distinct_id`. `LogHog.bare_capture` is a more direct interface for cases where we want to have control over properties that we're sending.